### PR TITLE
Bug fixes and updates

### DIFF
--- a/core/hooks/context_change.py
+++ b/core/hooks/context_change.py
@@ -116,15 +116,15 @@ class ContextChange(get_hook_baseclass()):
                         env_vars["CAMERA_RAW"] = show_camera_raw
                         env_vars["LUT"] = show_lut
 
-                if type == "Project":
-                    show_id = next_context.project['id']
-                    show_entity = next_context.sgtk.shotgun.find_one('Project', [['id', 'is', show_id]], ['code', field_camera_raw, field_lut])
-                    show_code = show_entity.get('code')
-                    show_camera_raw, show_lut = show_entity.get(field_camera_raw), show_entity.get(field_lut)
-                    env_vars["SHOW"] = show_code
-                    if show_camera_raw and show_lut:
-                        env_vars["CAMERA_RAW"] = show_camera_raw
-                        env_vars["LUT"] = show_lut
+            if next_context.project:
+                show_id = next_context.project['id']
+                show_entity = next_context.sgtk.shotgun.find_one('Project', [['id', 'is', show_id]], ['code', field_camera_raw, field_lut])
+                show_code = show_entity.get('code')
+                show_camera_raw, show_lut = show_entity.get(field_camera_raw), show_entity.get(field_lut)
+                env_vars["SHOW"] = show_code
+                if show_camera_raw and show_lut:
+                    env_vars["CAMERA_RAW"] = show_camera_raw
+                    env_vars["LUT"] = show_lut
 
             # set the env variables for OCIO to pick up
             for key, value in env_vars.iteritems():

--- a/core/schema/show/pipe/ocio/default.ocio
+++ b/core/schema/show/pipe/ocio/default.ocio
@@ -88,8 +88,8 @@ colorspaces:
 # and are provided for convenience and should not be modified.
 
   - !<ColorSpace>
-    name: Nuke - linear
-    family: Nuke
+    name: Legacy - linear
+    family: Legacy
     equalitygroup: ""
     bitdepth: 32f
     description: |
@@ -99,8 +99,8 @@ colorspaces:
     allocationvars: [-15, 6]
 
   - !<ColorSpace>
-    name: Nuke - sRGB
-    family: Nuke
+    name: Legacy - sRGB
+    family: Legacy
     equalitygroup: ""
     bitdepth: 32f
     description: |
@@ -114,8 +114,8 @@ colorspaces:
         - !<MatrixTransform> {matrix: [0.695452, 0.140679, 0.163869, 0, 0.0447946, 0.859671, 0.0955343, 0, -0.00552588, 0.00402521, 1.0015, 0, 0, 0, 0, 1]}
 
   - !<ColorSpace>
-    name: Nuke - sRGBf
-    family: Nuke
+    name: Legacy - sRGBf
+    family: Legacy
     equalitygroup: ""
     bitdepth: 32f
     description: |
@@ -129,8 +129,8 @@ colorspaces:
         - !<MatrixTransform> {matrix: [0.695452, 0.140679, 0.163869, 0, 0.0447946, 0.859671, 0.0955343, 0, -0.00552588, 0.00402521, 1.0015, 0, 0, 0, 0, 1]}
 
   - !<ColorSpace>
-    name: Nuke - rec709
-    family: Nuke
+    name: Legacy - rec709
+    family: Legacy
     equalitygroup: ""
     bitdepth: 32f
     description: |
@@ -144,8 +144,8 @@ colorspaces:
         - !<MatrixTransform> {matrix: [0.695452, 0.140679, 0.163869, 0, 0.0447946, 0.859671, 0.0955343, 0, -0.00552588, 0.00402521, 1.0015, 0, 0, 0, 0, 1]}
 
   - !<ColorSpace>
-    name: Nuke - Cineon
-    family: Nuke
+    name: Legacy - Cineon
+    family: Legacy
     equalitygroup: ""
     bitdepth: 32f
     description: |
@@ -159,8 +159,8 @@ colorspaces:
         - !<MatrixTransform> {matrix: [0.695452, 0.140679, 0.163869, 0, 0.0447946, 0.859671, 0.0955343, 0, -0.00552588, 0.00402521, 1.0015, 0, 0, 0, 0, 1]}
 
   - !<ColorSpace>
-    name: Nuke - Gamma1.8
-    family: Nuke
+    name: Legacy - Gamma1.8
+    family: Legacy
     equalitygroup: ""
     bitdepth: 32f
     description: |
@@ -174,8 +174,8 @@ colorspaces:
         - !<MatrixTransform> {matrix: [0.695452, 0.140679, 0.163869, 0, 0.0447946, 0.859671, 0.0955343, 0, -0.00552588, 0.00402521, 1.0015, 0, 0, 0, 0, 1]}
 
   - !<ColorSpace>
-    name: Nuke - Gamma2.2
-    family: Nuke
+    name: Legacy - Gamma2.2
+    family: Legacy
     equalitygroup: ""
     bitdepth: 32f
     description: |
@@ -189,8 +189,8 @@ colorspaces:
         - !<MatrixTransform> {matrix: [0.695452, 0.140679, 0.163869, 0, 0.0447946, 0.859671, 0.0955343, 0, -0.00552588, 0.00402521, 1.0015, 0, 0, 0, 0, 1]}
 
   - !<ColorSpace>
-    name: Nuke - Panalog
-    family: Nuke
+    name: Legacy - Panalog
+    family: Legacy
     equalitygroup: ""
     bitdepth: 32f
     description: |
@@ -204,8 +204,8 @@ colorspaces:
         - !<MatrixTransform> {matrix: [0.695452, 0.140679, 0.163869, 0, 0.0447946, 0.859671, 0.0955343, 0, -0.00552588, 0.00402521, 1.0015, 0, 0, 0, 0, 1]}
 
   - !<ColorSpace>
-    name: Nuke - REDLog
-    family: Nuke
+    name: Legacy - REDLog
+    family: Legacy
     equalitygroup: ""
     bitdepth: 32f
     description: |
@@ -219,8 +219,8 @@ colorspaces:
         - !<MatrixTransform> {matrix: [0.695452, 0.140679, 0.163869, 0, 0.0447946, 0.859671, 0.0955343, 0, -0.00552588, 0.00402521, 1.0015, 0, 0, 0, 0, 1]}
 
   - !<ColorSpace>
-    name: Nuke - ViperLog
-    family: Nuke
+    name: Legacy - ViperLog
+    family: Legacy
     equalitygroup: ""
     bitdepth: 32f
     description: |
@@ -234,8 +234,8 @@ colorspaces:
         - !<MatrixTransform> {matrix: [0.695452, 0.140679, 0.163869, 0, 0.0447946, 0.859671, 0.0955343, 0, -0.00552588, 0.00402521, 1.0015, 0, 0, 0, 0, 1]}
 
   - !<ColorSpace>
-    name: Nuke - AlexaV3LogC
-    family: Nuke
+    name: Legacy - AlexaV3LogC
+    family: Legacy
     equalitygroup: ""
     bitdepth: 32f
     description: |
@@ -249,8 +249,8 @@ colorspaces:
         - !<MatrixTransform> {matrix: [0.695452, 0.140679, 0.163869, 0, 0.0447946, 0.859671, 0.0955343, 0, -0.00552588, 0.00402521, 1.0015, 0, 0, 0, 0, 1]}
 
   - !<ColorSpace>
-    name: Nuke - PLogLin
-    family: Nuke
+    name: Legacy - PLogLin
+    family: Legacy
     equalitygroup: ""
     bitdepth: 32f
     description: |
@@ -264,8 +264,8 @@ colorspaces:
         - !<MatrixTransform> {matrix: [0.695452, 0.140679, 0.163869, 0, 0.0447946, 0.859671, 0.0955343, 0, -0.00552588, 0.00402521, 1.0015, 0, 0, 0, 0, 1]}
 
   - !<ColorSpace>
-    name: Nuke - SLog
-    family: Nuke
+    name: Legacy - SLog
+    family: Legacy
     equalitygroup: ""
     bitdepth: 32f
     description: |
@@ -279,8 +279,8 @@ colorspaces:
         - !<MatrixTransform> {matrix: [0.695452, 0.140679, 0.163869, 0, 0.0447946, 0.859671, 0.0955343, 0, -0.00552588, 0.00402521, 1.0015, 0, 0, 0, 0, 1]}
 
   - !<ColorSpace>
-    name: Nuke - raw
-    family: Nuke
+    name: Legacy - raw
+    family: Legacy
     equalitygroup: ""
     bitdepth: 32f
     description: |

--- a/core/schema/show/show/work/step/user/nukestudio.yml
+++ b/core/schema/show/show/work/step/user/nukestudio.yml
@@ -1,6 +1,0 @@
-# the type of dynamic content
-type: "static"
-
-# defer creation and only create this folder when Nuke starts
-defer_creation: "tk-nukestudio"
-

--- a/core/schema/show/show/work/step/user/nukestudio/snapshots/placeholder
+++ b/core/schema/show/show/work/step/user/nukestudio/snapshots/placeholder
@@ -1,4 +1,0 @@
-# This file is a placeholder to ensure that the parent folder is preserved and not deleted by git.
-# Any file named 'placeholder' will not be copied across when folders are created.
-# Note: You can which files should be ignored when folders are created in the ignore_files file,
-# located in the schema folder.

--- a/env/asset_step.yml
+++ b/env/asset_step.yml
@@ -18,7 +18,6 @@ engines:
   tk-desktop2: "@settings.tk-desktop2.all"
   tk-maya: "@settings.tk-maya.asset_step"
   tk-nuke: "@settings.tk-nuke.asset_step"
-  tk-nukestudio: "@settings.tk-nuke.nukestudio.asset_step"
   tk-nuke-render: "@settings.tk-nuke.render.asset_step"
   tk-photoshopcc: "@settings.tk-photoshopcc.asset_step"
   tk-shell: "@settings.tk-shell.asset_step"

--- a/env/includes/engine_locations.yml
+++ b/env/includes/engine_locations.yml
@@ -42,13 +42,13 @@ engines.tk-maya.location:
 engines.tk-nuke.location:
   name: tk-nuke
   ### App Store
-  type: app_store
-  version: v0.12.7
+  # type: app_store
+  # version: v0.12.7
   ### Toolkit Component Entity
-  # type: shotgun
-  # entity_type: CustomNonProjectEntity13
-  # field: sg_uploaded_app
-  # version: 1562 #tk-nuke-0.12.6.1
+  type: shotgun
+  entity_type: CustomNonProjectEntity13
+  field: sg_uploaded_app
+  version: 1965 #tk-nuke-0.12.7.1
   ## Dev
   # type: dev
   # path: ~/Documents/Github/tk-nuke_nx

--- a/env/includes/settings/tk-multi-breakdown.yml
+++ b/env/includes/settings/tk-multi-breakdown.yml
@@ -5,6 +5,6 @@ includes:
 
 ################################################################################
 
-settings.tk-multi-breakdown.nukestudio:
+settings.tk-multi-breakdown.hiero:
   hook_scene_operations: '{self}/tk-nuke_scene_operations.py'
   location: "@apps.tk-multi-breakdown.location"

--- a/env/includes/settings/tk-multi-loader2.yml
+++ b/env/includes/settings/tk-multi-loader2.yml
@@ -67,7 +67,7 @@ settings.tk-multi-loader2.nuke:
   location: "@apps.tk-multi-loader2.location"
 
 # nuke studio (actions hook)
-settings.tk-multi-loader2.nukestudio.project:
+settings.tk-multi-loader2.hiero.project:
   actions_hook: '{self}/tk-nuke_actions.py'
   action_mappings:
     Image: [clip_import]
@@ -93,7 +93,7 @@ settings.tk-multi-loader2.nukestudio.project:
   publish_filters: [["sg_status_list", "is_not", null]]
   location: "@apps.tk-multi-loader2.location"
 
-settings.tk-multi-loader2.nukestudio:
+settings.tk-multi-loader2.hiero:
   actions_hook: '{self}/tk-nuke_actions.py'
   action_mappings:
     Alembic Cache: [read_node]

--- a/env/includes/settings/tk-multi-publish2.yml
+++ b/env/includes/settings/tk-multi-publish2.yml
@@ -131,9 +131,9 @@ settings.tk-multi-publish2.nuke.shot_step:
 
 ################################################################################
 
-# ---- NukeStudio
+# ---- Hiero
 
-settings.tk-multi-publish2.nukestudio:
+settings.tk-multi-publish2.hiero:
   collector: "{self}/collector.py:{engine}/tk-multi-publish2/basic/collector.py"
   collector_settings:
       Work Template: show_hiero_work_file

--- a/env/includes/settings/tk-multi-workfiles2.yml
+++ b/env/includes/settings/tk-multi-workfiles2.yml
@@ -71,38 +71,22 @@ settings.tk-multi-workfiles2.launch_at_startup:
 
 settings.tk-multi-workfiles2.hiero.project:
   # saveas_default_name: edit
-  entities:
-  - caption: Projects
-    entity_type: Project
-    filters: []
-    hierarchy: [name]
-  # show_my_tasks: false
-    sub_hierarchy:
-      entity_type: Task
-      filters:
-        - [step, is_not, null]
-      link_field: entity
-      hierarchy: [step]
-  location: "@apps.tk-multi-workfiles2.location"
-
-settings.tk-multi-workfiles2.hiero.project_step:
-  # saveas_default_name: edit
-  entities:
-  - caption: Projects
-    entity_type: Project
-    filters: []
-    hierarchy: [name]
-  # show_my_tasks: false
-    sub_hierarchy:
-      entity_type: Task
-      filters:
-        - [step, is_not, null]
-      link_field: entity
-      hierarchy: [step]
   template_publish: show_hiero_pub_file
   template_publish_area: show_hiero_pub_area
   template_work: show_hiero_work_file
   template_work_area: show_hiero_work_area
+  entities:
+  - caption: Projects
+    entity_type: Project
+    filters: []
+    hierarchy: [name]
+  # show_my_tasks: false
+    sub_hierarchy:
+      entity_type: Task
+      filters:
+        - [step, is_not, null]
+      link_field: entity
+      hierarchy: [step]
   location: "@apps.tk-multi-workfiles2.location"
 
 ################################################################################

--- a/env/includes/settings/tk-nuke.yml
+++ b/env/includes/settings/tk-nuke.yml
@@ -23,62 +23,21 @@ settings.tk-nuke.hiero.project:
   apps:
     tk-multi-about:
       location: "@apps.tk-multi-about.location"
-    tk-multi-publish2: "@settings.tk-multi-publish2.nukestudio"
+    tk-multi-publish2: "@settings.tk-multi-publish2.hiero"
     tk-multi-shotgunpanel: "@settings.tk-multi-shotgunpanel.hiero"
     tk-multi-snapshot: "@settings.tk-multi-snapshot.hiero"
     tk-multi-workfiles2: "@settings.tk-multi-workfiles2.hiero.project"
     tk-hiero-openinshotgun:
       location: "@apps.tk-hiero-openinshotgun.location"
     tk-hiero-export: "@settings.tk-hiero-export"
-    tk-multi-breakdown: "@settings.tk-multi-breakdown.nukestudio"
-    tk-multi-loader2: "@settings.tk-multi-loader2.nukestudio.project"
+    tk-multi-breakdown: "@settings.tk-multi-breakdown.hiero"
+    tk-multi-loader2: "@settings.tk-multi-loader2.hiero.project"
   # engine settings
   bin_context_menu:
   - app_instance: tk-multi-workfiles2
     keep_in_menu: false
-    name: "File Save..."
+    name: "Open..."
     requires_selection: true
-  - app_instance: tk-multi-snapshot
-    keep_in_menu: false
-    name: "Snapshot..."
-    requires_selection: true
-  - app_instance: tk-multi-snapshot
-    keep_in_menu: false
-    name: "Snapshot History..."
-    requires_selection: true
-  - app_instance: tk-multi-publish2
-    keep_in_menu: false
-    name: "Publish..."
-    requires_selection: true
-  spreadsheet_context_menu:
-  - app_instance: tk-hiero-openinshotgun
-    keep_in_menu: false
-    name: "Open in Shotgun"
-    requires_selection: true
-  timeline_context_menu:
-  - app_instance: tk-hiero-openinshotgun
-    keep_in_menu: false
-    name: "Open in Shotgun"
-    requires_selection: true
-  menu_favourites:
-  - {app_instance: tk-multi-workfiles2, name: File Open..., hotkey: "ctrl+o"}
-  location: "@engines.tk-nuke.location"
-
-settings.tk-nuke.hiero.project_step:
-  apps:
-    tk-multi-about:
-      location: "@apps.tk-multi-about.location"
-    tk-multi-publish2: "@settings.tk-multi-publish2.nukestudio"
-    tk-multi-shotgunpanel: "@settings.tk-multi-shotgunpanel.hiero"
-    tk-multi-snapshot: "@settings.tk-multi-snapshot.hiero"
-    tk-multi-workfiles2: "@settings.tk-multi-workfiles2.hiero.project_step"
-    tk-hiero-openinshotgun:
-      location: "@apps.tk-hiero-openinshotgun.location"
-    tk-hiero-export: "@settings.tk-hiero-export"
-    tk-multi-breakdown: "@settings.tk-multi-breakdown.nukestudio"
-    tk-multi-loader2: "@settings.tk-multi-loader2.nukestudio.project"
-  # engine settings
-  bin_context_menu:
   - app_instance: tk-multi-workfiles2
     keep_in_menu: false
     name: "File Save..."
@@ -232,127 +191,173 @@ settings.tk-nuke.shot_step:
 # NukeStudio
 
 # asset_step
-settings.tk-nuke.nukestudio.asset_step:
-  apps:
-    tk-multi-about:
-      location: "@apps.tk-multi-about.location"
-    tk-multi-setframerange:
-      location: "@apps.tk-multi-setframerange.location"
-      sg_in_frame_field: sg_head_in
-      sg_out_frame_field: sg_tail_out
-      always_lock_range: true
-    tk-multi-breakdown: "@settings.tk-multi-breakdown.nukestudio"
-    tk-multi-loader2: "@settings.tk-multi-loader2.nukestudio"
-    tk-multi-publish2: "@settings.tk-multi-publish2.nukestudio"
-    tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
-    tk-multi-shotgunpanel: "@settings.tk-multi-shotgunpanel.nukestudio"
-    tk-multi-snapshot: "@settings.tk-multi-snapshot.hiero"
-    tk-multi-workfiles2: "@settings.tk-multi-workfiles2.hiero.project"
-    tk-nuke-writenode: "@settings.tk-nuke-writenode.asset"
-  bin_context_menu:
-  - app_instance: tk-multi-workfiles2
-    keep_in_menu: false
-    name: "File Save..."
-    requires_selection: true
-  - app_instance: tk-multi-snapshot
-    keep_in_menu: false
-    name: "Snapshot..."
-    requires_selection: true
-  - app_instance: tk-multi-snapshot
-    keep_in_menu: false
-    name: "Snapshot History..."
-    requires_selection: true
-  - app_instance: tk-multi-publish2
-    keep_in_menu: false
-    name: "Publish..."
-    requires_selection: true
-  menu_favourites:
-  - {app_instance: tk-multi-workfiles2, name: File Open..., hotkey: "ctrl+o"}
-  location: '@engines.tk-nuke.location'
+# settings.tk-nuke.nukestudio.asset_step:
+#   apps:
+#     tk-multi-about:
+#       location: "@apps.tk-multi-about.location"
+#     tk-multi-setframerange:
+#       location: "@apps.tk-multi-setframerange.location"
+#       sg_in_frame_field: sg_head_in
+#       sg_out_frame_field: sg_tail_out
+#       always_lock_range: true
+#     tk-multi-breakdown: "@settings.tk-multi-breakdown.nukestudio"
+#     tk-multi-loader2: "@settings.tk-multi-loader2.nukestudio"
+#     tk-multi-publish2: "@settings.tk-multi-publish2.nukestudio"
+#     tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
+#     tk-multi-shotgunpanel: "@settings.tk-multi-shotgunpanel.nukestudio"
+#     tk-multi-snapshot: "@settings.tk-multi-snapshot.hiero"
+#     tk-multi-workfiles2: "@settings.tk-multi-workfiles2.hiero.project"
+#     tk-nuke-writenode: "@settings.tk-nuke-writenode.asset"
+#   bin_context_menu:
+#   - app_instance: tk-multi-workfiles2
+#     keep_in_menu: false
+#     name: "File Save..."
+#     requires_selection: true
+#   - app_instance: tk-multi-snapshot
+#     keep_in_menu: false
+#     name: "Snapshot..."
+#     requires_selection: true
+#   - app_instance: tk-multi-snapshot
+#     keep_in_menu: false
+#     name: "Snapshot History..."
+#     requires_selection: true
+#   - app_instance: tk-multi-publish2
+#     keep_in_menu: false
+#     name: "Publish..."
+#     requires_selection: true
+#   menu_favourites:
+#   - {app_instance: tk-multi-workfiles2, name: File Open..., hotkey: "ctrl+o"}
+#   location: '@engines.tk-nuke.location'
 
 # project
-settings.tk-nuke.nukestudio.project:
-  apps:
-    tk-multi-about:
-      location: "@apps.tk-multi-about.location"
-    tk-multi-publish2: "@settings.tk-multi-publish2.nukestudio"
-    tk-multi-shotgunpanel: "@settings.tk-multi-shotgunpanel.nukestudio"
-    tk-multi-snapshot: "@settings.tk-multi-snapshot.hiero"
-    tk-multi-workfiles2: "@settings.tk-multi-workfiles2.hiero.project"
-    tk-hiero-openinshotgun:
-      location: "@apps.tk-hiero-openinshotgun.location"
-    tk-hiero-export: "@settings.tk-hiero-export"
-    tk-multi-breakdown: "@settings.tk-multi-breakdown.nukestudio"
-    tk-multi-loader2: "@settings.tk-multi-loader2.nukestudio.project"
-  bin_context_menu:
-  - app_instance: tk-multi-workfiles2
-    keep_in_menu: false
-    name: "File Save..."
-    requires_selection: true
-  - app_instance: tk-multi-snapshot
-    keep_in_menu: false
-    name: "Snapshot..."
-    requires_selection: true
-  - app_instance: tk-multi-snapshot
-    keep_in_menu: false
-    name: "Snapshot History..."
-    requires_selection: true
-  - app_instance: tk-multi-publish2
-    keep_in_menu: false
-    name: "Publish..."
-    requires_selection: true
-  spreadsheet_context_menu:
-  - app_instance: tk-hiero-openinshotgun
-    keep_in_menu: false
-    name: "Open in Shotgun"
-    requires_selection: true
-  timeline_context_menu:
-  - app_instance: tk-hiero-openinshotgun
-    keep_in_menu: false
-    name: "Open in Shotgun"
-    requires_selection: true
-  menu_favourites:
-  - {app_instance: tk-multi-workfiles2, name: File Open..., hotkey: "ctrl+o"}
-  location: '@engines.tk-nuke.location'
+# settings.tk-nuke.nukestudio.project:
+#   apps:
+#     tk-multi-about:
+#       location: "@apps.tk-multi-about.location"
+#     tk-multi-publish2: "@settings.tk-multi-publish2.nukestudio"
+#     tk-multi-shotgunpanel: "@settings.tk-multi-shotgunpanel.nukestudio"
+#     tk-multi-snapshot: "@settings.tk-multi-snapshot.hiero"
+#     tk-multi-workfiles2: "@settings.tk-multi-workfiles2.hiero.project"
+#     tk-hiero-openinshotgun:
+#       location: "@apps.tk-hiero-openinshotgun.location"
+#     tk-hiero-export: "@settings.tk-hiero-export"
+#     tk-multi-breakdown: "@settings.tk-multi-breakdown.nukestudio"
+#     tk-multi-loader2: "@settings.tk-multi-loader2.nukestudio.project"
+#   bin_context_menu:
+#   - app_instance: tk-multi-workfiles2
+#     keep_in_menu: false
+#     name: "File Save..."
+#     requires_selection: true
+#   - app_instance: tk-multi-snapshot
+#     keep_in_menu: false
+#     name: "Snapshot..."
+#     requires_selection: true
+#   - app_instance: tk-multi-snapshot
+#     keep_in_menu: false
+#     name: "Snapshot History..."
+#     requires_selection: true
+#   - app_instance: tk-multi-publish2
+#     keep_in_menu: false
+#     name: "Publish..."
+#     requires_selection: true
+#   spreadsheet_context_menu:
+#   - app_instance: tk-hiero-openinshotgun
+#     keep_in_menu: false
+#     name: "Open in Shotgun"
+#     requires_selection: true
+#   timeline_context_menu:
+#   - app_instance: tk-hiero-openinshotgun
+#     keep_in_menu: false
+#     name: "Open in Shotgun"
+#     requires_selection: true
+#   menu_favourites:
+#   - {app_instance: tk-multi-workfiles2, name: File Open..., hotkey: "ctrl+o"}
+#   location: '@engines.tk-nuke.location'
+
+# project
+# settings.tk-nuke.nukestudio.project_step:
+#   apps:
+#     tk-multi-about:
+#       location: "@apps.tk-multi-about.location"
+#     tk-multi-publish2: "@settings.tk-multi-publish2.nukestudio"
+#     tk-multi-shotgunpanel: "@settings.tk-multi-shotgunpanel.hiero"
+#     tk-multi-snapshot: "@settings.tk-multi-snapshot.hiero"
+#     tk-multi-workfiles2: "@settings.tk-multi-workfiles2.hiero.project_step"
+#     tk-hiero-openinshotgun:
+#       location: "@apps.tk-hiero-openinshotgun.location"
+#     tk-hiero-export: "@settings.tk-hiero-export"
+#     tk-multi-breakdown: "@settings.tk-multi-breakdown.nukestudio"
+#     tk-multi-loader2: "@settings.tk-multi-loader2.nukestudio.project"
+#   # engine settings
+#   bin_context_menu:
+#   - app_instance: tk-multi-workfiles2
+#     keep_in_menu: false
+#     name: "File Save..."
+#     requires_selection: true
+#   - app_instance: tk-multi-snapshot
+#     keep_in_menu: false
+#     name: "Snapshot..."
+#     requires_selection: true
+#   - app_instance: tk-multi-snapshot
+#     keep_in_menu: false
+#     name: "Snapshot History..."
+#     requires_selection: true
+#   - app_instance: tk-multi-publish2
+#     keep_in_menu: false
+#     name: "Publish..."
+#     requires_selection: true
+#   spreadsheet_context_menu:
+#   - app_instance: tk-hiero-openinshotgun
+#     keep_in_menu: false
+#     name: "Open in Shotgun"
+#     requires_selection: true
+#   timeline_context_menu:
+#   - app_instance: tk-hiero-openinshotgun
+#     keep_in_menu: false
+#     name: "Open in Shotgun"
+#     requires_selection: true
+#   menu_favourites:
+#   - {app_instance: tk-multi-workfiles2, name: File Open..., hotkey: "ctrl+o"}
+#   location: "@engines.tk-nuke.location"
 
 # shot_step
-settings.tk-nuke.nukestudio.shot_step:
-  apps:
-    tk-multi-about:
-      location: "@apps.tk-multi-about.location"
-    tk-multi-setframerange:
-      location: "@apps.tk-multi-setframerange.location"
-      sg_in_frame_field: sg_head_in
-      sg_out_frame_field: sg_tail_out
-      always_lock_range: true
-    tk-multi-breakdown: "@settings.tk-multi-breakdown.nukestudio"
-    tk-multi-loader2: "@settings.tk-multi-loader2.nukestudio"
-    tk-multi-publish2: "@settings.tk-multi-publish2.nukestudio"
-    tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
-    tk-multi-shotgunpanel: "@settings.tk-multi-shotgunpanel.nukestudio"
-    tk-multi-snapshot: "@settings.tk-multi-snapshot.hiero"
-    tk-multi-workfiles2: "@settings.tk-multi-workfiles2.hiero.project"
-    tk-nuke-writenode: "@settings.tk-nuke-writenode.shot"
-  bin_context_menu:
-  - app_instance: tk-multi-workfiles2
-    keep_in_menu: false
-    name: "File Save..."
-    requires_selection: true
-  - app_instance: tk-multi-snapshot
-    keep_in_menu: false
-    name: "Snapshot..."
-    requires_selection: true
-  - app_instance: tk-multi-snapshot
-    keep_in_menu: false
-    name: "Snapshot History..."
-    requires_selection: true
-  - app_instance: tk-multi-publish2
-    keep_in_menu: false
-    name: "Publish..."
-    requires_selection: true
-  menu_favourites:
-  - {app_instance: tk-multi-workfiles2, name: File Open..., hotkey: "ctrl+o"}
-  location: '@engines.tk-nuke.location'
+# settings.tk-nuke.nukestudio.shot_step:
+#   apps:
+#     tk-multi-about:
+#       location: "@apps.tk-multi-about.location"
+#     tk-multi-setframerange:
+#       location: "@apps.tk-multi-setframerange.location"
+#       sg_in_frame_field: sg_head_in
+#       sg_out_frame_field: sg_tail_out
+#       always_lock_range: true
+#     tk-multi-breakdown: "@settings.tk-multi-breakdown.nukestudio"
+#     tk-multi-loader2: "@settings.tk-multi-loader2.nukestudio"
+#     tk-multi-publish2: "@settings.tk-multi-publish2.nukestudio"
+#     tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
+#     tk-multi-shotgunpanel: "@settings.tk-multi-shotgunpanel.nukestudio"
+#     tk-multi-snapshot: "@settings.tk-multi-snapshot.hiero"
+#     tk-multi-workfiles2: "@settings.tk-multi-workfiles2.hiero.project"
+#     tk-nuke-writenode: "@settings.tk-nuke-writenode.shot"
+#   bin_context_menu:
+#   - app_instance: tk-multi-workfiles2
+#     keep_in_menu: false
+#     name: "File Save..."
+#     requires_selection: true
+#   - app_instance: tk-multi-snapshot
+#     keep_in_menu: false
+#     name: "Snapshot..."
+#     requires_selection: true
+#   - app_instance: tk-multi-snapshot
+#     keep_in_menu: false
+#     name: "Snapshot History..."
+#     requires_selection: true
+#   - app_instance: tk-multi-publish2
+#     keep_in_menu: false
+#     name: "Publish..."
+#     requires_selection: true
+#   menu_favourites:
+#   - {app_instance: tk-multi-workfiles2, name: File Open..., hotkey: "ctrl+o"}
+#   location: '@engines.tk-nuke.location'
 
 
 ################################################################################

--- a/env/project.yml
+++ b/env/project.yml
@@ -16,11 +16,10 @@ includes:
 
 engines:
   tk-desktop: "@settings.tk-desktop.project"
-  tk-hiero: "@settings.tk-nuke.hiero.project"
+  # tk-hiero: "@settings.tk-nuke.hiero.project"
   tk-maya: "@settings.tk-maya.project"
   tk-nuke: "@settings.tk-nuke.project"
   tk-nuke-render: "@settings.tk-nuke.render.project"
-  tk-nukestudio: "@settings.tk-nuke.nukestudio.project"
   tk-photoshopcc: "@settings.tk-photoshopcc.project"
   tk-shell: "@settings.tk-shell.project"
   tk-shotgun: "@settings.tk-shotgun.project"

--- a/env/project_step.yml
+++ b/env/project_step.yml
@@ -16,11 +16,10 @@ includes:
 
 engines:
   tk-desktop: "@settings.tk-desktop.project"
-  tk-hiero: "@settings.tk-nuke.hiero.project_step"
+  tk-hiero: "@settings.tk-nuke.hiero.project"
   tk-maya: "@settings.tk-maya.project"
   tk-nuke: "@settings.tk-nuke.project"
   tk-nuke-render: "@settings.tk-nuke.render.project"
-  tk-nukestudio: "@settings.tk-nuke.nukestudio.project"
   tk-photoshopcc: "@settings.tk-photoshopcc.project"
   tk-shell: "@settings.tk-shell.project"
   tk-shotgun: "@settings.tk-shotgun.project"

--- a/env/sequence_step.yml
+++ b/env/sequence_step.yml
@@ -19,7 +19,6 @@ engines:
   tk-desktop2: "@settings.tk-desktop2.all"
   tk-maya: "@settings.tk-maya.shot_step"
   tk-nuke: "@settings.tk-nuke.shot_step"
-  tk-nukestudio: "@settings.tk-nuke.nukestudio.shot_step"
   tk-nuke-render: "@settings.tk-nuke.render.shot_step"
   tk-photoshopcc: "@settings.tk-photoshopcc.shot_step"
   tk-shell: "@settings.tk-shell.shot_step"

--- a/env/shot_step.yml
+++ b/env/shot_step.yml
@@ -19,7 +19,6 @@ engines:
   tk-desktop2: "@settings.tk-desktop2.all"
   tk-maya: "@settings.tk-maya.shot_step"
   tk-nuke: "@settings.tk-nuke.shot_step"
-  tk-nukestudio: "@settings.tk-nuke.nukestudio.shot_step"
   tk-nuke-render: "@settings.tk-nuke.render.shot_step"
   tk-photoshopcc: "@settings.tk-photoshopcc.shot_step"
   tk-shell: "@settings.tk-shell.shot_step"

--- a/hooks/tk-multi-launchapp/before_register_command.py
+++ b/hooks/tk-multi-launchapp/before_register_command.py
@@ -30,10 +30,13 @@ class BeforeRegisterCommand(HookBaseClass):
         # We're going to end up getting a SoftwareVersion for Nuke Studio that
         # wants to route us to the tk-nuke engine instance. We don't want that, so
         # we'll redirect to tk-nukestudio.
-        if software_version.product == "NukeStudio":
-            engine_instance_name = "tk-nukestudio"
+        # if software_version.product == "NukeStudio":
+        #     engine_instance_name = "tk-nukestudio"
+        #
+        # if software_version.product == "Hiero":
+        #     engine_instance_name = "tk-hiero"
 
-        if software_version.product == "Hiero":
+        if software_version.product in ["NukeStudio", "Hiero"]:
             engine_instance_name = "tk-hiero"
 
         return engine_instance_name


### PR DESCRIPTION
- fixed error in context_change, envars not getting properly set in 
Project context
- default ocio config change: all 'Nuke' entries now labeled 'Legacy' so 
its less App specific
- updated tk-nuke to add SG's changes in v0.12.7
- big updates to nukestudio/hiero integration:
    - made all nukestudio entries point to hiero
    - removed nukestudio/hiero apps from tk-desktop luancher because with current config they need to be in a project_step environment.
    - can launch nukestudio/hiero from project_step task in web interface or sg create (not tested in create)