### PR TITLE
Nuke and publishing updates

### DIFF
--- a/env/includes/settings/tk-multi-publish2.yml
+++ b/env/includes/settings/tk-multi-publish2.yml
@@ -12,6 +12,7 @@ publish_help_url: &help_url "https://support.shotgunsoftware.com/hc/en-us/articl
 # ---- Stand alone publish
 
 settings.tk-multi-publish2.standalone:
+  path_info: "{config}/tk-multi-publish2/path_info.py"
   collector: "{config}/tk-multi-publish2/collector.py"
   publish_plugins:
   - name: Publish to Shotgun
@@ -26,6 +27,7 @@ settings.tk-multi-publish2.standalone:
 
 # asset step
 settings.tk-multi-publish2.maya.asset_step:
+  path_info: "{config}/tk-multi-publish2/path_info.py"
   collector: "{self}/collector.py:{engine}/tk-multi-publish2/basic/collector.py"
   collector_settings:
       Work Template: asset_maya_work_file
@@ -45,6 +47,7 @@ settings.tk-multi-publish2.maya.asset_step:
 
 # sequence step
 settings.tk-multi-publish2.maya.seq_step:
+  path_info: "{config}/tk-multi-publish2/path_info.py"
   collector: "{self}/collector.py:{engine}/tk-multi-publish2/basic/collector.py"
   collector_settings:
       Work Template: seq_maya_work_file
@@ -64,6 +67,7 @@ settings.tk-multi-publish2.maya.seq_step:
 
 # shot step
 settings.tk-multi-publish2.maya.shot_step:
+  path_info: "{config}/tk-multi-publish2/path_info.py"
   collector: "{self}/collector.py:{engine}/tk-multi-publish2/basic/collector.py"
   collector_settings:
       Work Template: shot_maya_work_file
@@ -87,6 +91,7 @@ settings.tk-multi-publish2.maya.shot_step:
 
 # asset step
 settings.tk-multi-publish2.houdini.asset_step:
+  path_info: "{config}/tk-multi-publish2/path_info.py"
   collector: "{self}/collector.py:{engine}/tk-multi-publish2/basic/collector.py"
   collector_settings:
       Work Template: asset_houdini_work_file
@@ -109,6 +114,7 @@ settings.tk-multi-publish2.houdini.asset_step:
 
 # seq step
 settings.tk-multi-publish2.houdini.seq_step:
+  path_info: "{config}/tk-multi-publish2/path_info.py"
   collector: "{self}/collector.py:{engine}/tk-multi-publish2/basic/collector.py"
   collector_settings:
       Work Template: seq_houdini_work_file
@@ -131,6 +137,7 @@ settings.tk-multi-publish2.houdini.seq_step:
 
 # shot step
 settings.tk-multi-publish2.houdini.shot_step:
+  path_info: "{config}/tk-multi-publish2/path_info.py"
   collector: "{self}/collector.py:{engine}/tk-multi-publish2/basic/collector.py"
   collector_settings:
       Work Template: shot_houdini_work_file
@@ -256,6 +263,7 @@ settings.tk-multi-publish2.hiero:
 
 # asset step
 settings.tk-multi-publish2.photoshop.asset_step:
+  path_info: "{config}/tk-multi-publish2/path_info.py"
   collector: "{self}/collector.py:{engine}/tk-multi-publish2/basic/collector.py"
   collector_settings:
       Work Template: asset_photoshop_work_file
@@ -281,6 +289,7 @@ settings.tk-multi-publish2.photoshop.asset_step:
 
 # seq_step
 settings.tk-multi-publish2.photoshop.seq_step:
+  path_info: "{config}/tk-multi-publish2/path_info.py"
   collector: "{self}/collector.py:{engine}/tk-multi-publish2/basic/collector.py"
   collector_settings:
       Work Template: seq_photoshop_work_file
@@ -306,6 +315,7 @@ settings.tk-multi-publish2.photoshop.seq_step:
 
 # shot_step
 settings.tk-multi-publish2.photoshop.shot_step:
+  path_info: "{config}/tk-multi-publish2/path_info.py"
   collector: "{self}/collector.py:{engine}/tk-multi-publish2/basic/collector.py"
   collector_settings:
       Work Template: shot_photoshop_work_file

--- a/env/includes/settings/tk-nuke-writenode.yml
+++ b/env/includes/settings/tk-nuke-writenode.yml
@@ -7,6 +7,7 @@ includes:
 
 # common
 image_categories: &image_categories
+  - out
   - comp
   - precomp
   - mattes
@@ -14,6 +15,7 @@ image_categories: &image_categories
   - rotoreview
   - paint
   - demo
+  - dataset
   - animcomp
   - autocomp
   - cfxcomp
@@ -50,7 +52,7 @@ settings.tk-nuke-writenode.asset:
     tile_color: []
   - file_type: mov
     name: QuickTime Movie
-    promote_write_knobs: 
+    promote_write_knobs:
       - mov64_fps
       - mov64_codec
       - mov_prores_codec_profile
@@ -141,7 +143,7 @@ settings.tk-nuke-writenode.seq:
     tile_color: []
   - file_type: mov
     name: QuickTime Movie
-    promote_write_knobs: 
+    promote_write_knobs:
       - mov64_fps
       - mov64_codec
       - mov_prores_codec_profile
@@ -232,7 +234,7 @@ settings.tk-nuke-writenode.shot:
     tile_color: []
   - file_type: mov
     name: QuickTime Movie
-    promote_write_knobs: 
+    promote_write_knobs:
       - mov64_fps
       - mov64_codec
       - mov_prores_codec_profile

--- a/hooks/tk-multi-publish2/attach_to_version.py
+++ b/hooks/tk-multi-publish2/attach_to_version.py
@@ -74,7 +74,6 @@ class AttachToVersionPlugin(HookBaseClass):
         """
         return {}
 
-
     @property
     def item_filters(self):
         """
@@ -116,14 +115,19 @@ class AttachToVersionPlugin(HookBaseClass):
         """
 
         path = item.properties.get("path")
-        skip_attach =  item.properties.get("skip_version_attach")
+        skip_attach = item.properties.get("skip_version_attach")
+        start_unchecked = item.properties.get("start_unchecked")
         accepted = False
-    
+        check = True
+
         if path and not skip_attach:
             accept = True
 
+        if start_unchecked:
+            check = False
+
         # return the accepted info
-        return {"accepted": accept}
+        return {"accepted": accept, "checked": check}
 
     def validate(self, settings, item):
         """
@@ -141,7 +145,6 @@ class AttachToVersionPlugin(HookBaseClass):
 
         create_version = False
         version_item = item
-
 
         # Look for an item up the tree that has a create_version flag, meaning a version will be created.
         while not create_version and version_item:
@@ -215,7 +218,7 @@ class AttachToVersionPlugin(HookBaseClass):
         # get the item that created the version entry
         version_item = item.local_properties.version_item
 
-        #check to see if we have any fun stuff to add
+        # check to see if we have any fun stuff to add
         first_frame = item.properties.get("first_frame")
         last_frame = item.properties.get("last_frame")
         width = item.properties.get("width")
@@ -235,8 +238,8 @@ class AttachToVersionPlugin(HookBaseClass):
 
             if item.type_spec in ["file.image", "file.image.sequence"]:
                 version_item.properties.version_finalize["update"].update({"sg_path_to_frames": path})
-                ## the RV screening room seems to apply the aspect_ratio as the pixel_aspect ratio and screws this whole thing up
-                ## so until this is fixed im turning off adding sg_frames_aspect_ratio to the version entity.
+                # the RV screening room seems to apply the aspect_ratio as the pixel_aspect ratio and screws this whole thing up
+                # so until this is fixed im turning off adding sg_frames_aspect_ratio to the version entity.
                 # if width and height and pixel_aspect:
                 #     aspect_ratio = float((width*pixel_aspect)/height)
                 #     version_item.properties.version_finalize["update"].update({"sg_frames_aspect_ratio": aspect_ratio})
@@ -246,14 +249,13 @@ class AttachToVersionPlugin(HookBaseClass):
             if item.type_spec in ["file.video"]:
                 version_item.properties.version_finalize["update"].update({"sg_path_to_movie": path})
                 version_item.properties.version_finalize["upload"].update({"sg_uploaded_movie": path})
-                ## the RV screening room seems to apply the aspect_ratio as the pixel_aspect ratio and screws this whole thing up
-                ## so until this is fixed im turning off adding sg_movie_aspect_ratio to the version entity.
+                # the RV screening room seems to apply the aspect_ratio as the pixel_aspect ratio and screws this whole thing up
+                # so until this is fixed im turning off adding sg_movie_aspect_ratio to the version entity.
                 # if width and height and pixel_aspect:
                 #     aspect_ratio = float((width*pixel_aspect)/height)
                 #     version_item.properties.version_finalize["update"].update({"sg_movie_aspect_ratio": aspect_ratio})
                 if slate_frame:
                     version_item.properties.version_finalize["update"].update({"sg_movie_has_slate": True})
-
 
             self.logger.debug(
                 "Version finalize tasks...",

--- a/hooks/tk-multi-publish2/collector.py
+++ b/hooks/tk-multi-publish2/collector.py
@@ -237,10 +237,11 @@ class BasicSceneCollector(HookBaseClass):
                 is_sequence = True
                 item_info["icon_path"] = self._get_icon_path("image_sequence.png")
 
-        display_name = publisher.util.get_publish_name(path, sequence=is_sequence)
+        publish_name = publisher.util.get_publish_name(path, sequence=is_sequence)
+        publish_code = publisher.util.get_publish_name(path, sequence=is_sequence, return_code=True)
 
         # create and populate the item
-        file_item = parent_item.create_item(item_type, type_display, display_name)
+        file_item = parent_item.create_item(item_type, type_display, publish_code)
         file_item.set_icon_from_path(item_info["icon_path"])
 
         # if the supplied path is an image, use the path as the thumbnail.
@@ -253,7 +254,7 @@ class BasicSceneCollector(HookBaseClass):
         # all we know about the file is its path. set the path in its
         # properties for the plugins to use for processing.
         file_item.properties["path"] = evaluated_path
-        file_item.properties["publish_name"] = display_name
+        file_item.properties["publish_name"] = publish_name
 
         if is_sequence:
             # include an indicator that this is an image sequence and the known
@@ -310,12 +311,15 @@ class BasicSceneCollector(HookBaseClass):
             # thumbnail and to generate the display name
             img_seq_files.sort()
             first_frame_file = img_seq_files[0]
-            display_name = publisher.util.get_publish_name(
+            publish_name = publisher.util.get_publish_name(
                 first_frame_file, sequence=True
+            )
+            publish_code = publisher.util.get_publish_name(
+                first_frame_file, sequence=True, return_code=True
             )
 
             # create and populate the item
-            file_item = parent_item.create_item(item_type, type_display, display_name)
+            file_item = parent_item.create_item(item_type, type_display, publish_code)
             icon_path = self._get_icon_path(icon_name)
             file_item.set_icon_from_path(icon_path)
 
@@ -328,6 +332,7 @@ class BasicSceneCollector(HookBaseClass):
             # all we know about the file is its path. set the path in its
             # properties for the plugins to use for processing.
             file_item.properties["path"] = image_seq_path
+            file_item.properties["publish_name"] = publish_name
             file_item.properties["sequence_paths"] = img_seq_files
 
             self.logger.info("Collected file: %s" % (image_seq_path,))

--- a/hooks/tk-multi-publish2/collector.py
+++ b/hooks/tk-multi-publish2/collector.py
@@ -237,8 +237,7 @@ class BasicSceneCollector(HookBaseClass):
                 is_sequence = True
                 item_info["icon_path"] = self._get_icon_path("image_sequence.png")
 
-        publish_name = publisher.util.get_publish_name(path, sequence=is_sequence)
-        publish_code = publisher.util.get_publish_name(path, sequence=is_sequence, return_code=True)
+        publish_name, publish_code = publisher.util.get_publish_name(path, sequence=is_sequence)
 
         # create and populate the item
         file_item = parent_item.create_item(item_type, type_display, publish_code)
@@ -311,11 +310,8 @@ class BasicSceneCollector(HookBaseClass):
             # thumbnail and to generate the display name
             img_seq_files.sort()
             first_frame_file = img_seq_files[0]
-            publish_name = publisher.util.get_publish_name(
+            publish_name, publish_code = publisher.util.get_publish_name(
                 first_frame_file, sequence=True
-            )
-            publish_code = publisher.util.get_publish_name(
-                first_frame_file, sequence=True, return_code=True
             )
 
             # create and populate the item

--- a/hooks/tk-multi-publish2/collector_tk-nuke.py
+++ b/hooks/tk-multi-publish2/collector_tk-nuke.py
@@ -285,6 +285,11 @@ class NukeSessionCollector(HookBaseClass):
                     parent_item, file_path, frame_sequence=True
                 )
 
+                # check if the theres a slate frame
+                slate_frame = node.input(0).metadata().get('nx/slate_frame')
+                if slate_frame:
+                    item.properties["slate_frame"] = int(slate_frame)
+
                 item.properties["node"] = node
                 item.properties["first_frame"] = first_frame
                 item.properties["last_frame"] = last_frame
@@ -335,6 +340,12 @@ class NukeSessionCollector(HookBaseClass):
 
             item.properties["node"] = node
             item.properties["skip_version_attach"] = True
+            item.properties["start_unchecked"] = True
+            item.properties["first_frame"] = first_frame
+            item.properties["last_frame"] = last_frame
+            item.properties["width"] = node.width()
+            item.properties["height"] = node.height()
+            item.properties["pixel_aspect"] = node.pixelAspect()
 
             # the item has been created. update the display name to include
             # the nuke node to make it clear to the user how it was
@@ -395,7 +406,6 @@ class NukeSessionCollector(HookBaseClass):
             item.properties["width"] = node.width()
             item.properties["height"] = node.height()
             item.properties["pixel_aspect"] = node.pixelAspect()
-
 
             if node.knob("use_limit").getValue():
                 item.properties["first_frame"] = int(node.knob("first").getValue())

--- a/hooks/tk-multi-publish2/path_info.py
+++ b/hooks/tk-multi-publish2/path_info.py
@@ -69,7 +69,7 @@ class BasicPathInfo(HookBaseClass):
             publish_name = publish_code = match.group("prefix")
             if match.group("version"):
                 publish_code += match.group("ver_sep")
-                publish_code += match.group("version")
+                publish_code += "v" + match.group("version")
             if match.group("rep"):
                 publish_name += match.group("rep_sep")
                 publish_name += match.group("rep")

--- a/hooks/tk-multi-publish2/path_info.py
+++ b/hooks/tk-multi-publish2/path_info.py
@@ -29,7 +29,7 @@ class BasicPathInfo(HookBaseClass):
     Methods for basic file path parsing.
     """
 
-    def get_publish_name(self, path, sequence=False, return_code=False):
+    def get_publish_name(self, path, sequence=False):
         """
         Given a file path, return the display name to use for publishing.
 
@@ -87,12 +87,8 @@ class BasicPathInfo(HookBaseClass):
             publish_name = filename
             publish_code = filename
 
-        if return_code:
-            logger.debug("Returning publish code: %s" % (publish_name,))
-            return publish_code
-        else:
-            logger.debug("Returning publish name: %s" % (publish_name,))
-            return publish_name
+        logger.debug("Returning publish name, publish code: %s, " % (publish_name, publish_code))
+        return publish_name, publish_code
 
     def get_version_number(self, path):
         """

--- a/hooks/tk-multi-publish2/path_info.py
+++ b/hooks/tk-multi-publish2/path_info.py
@@ -29,7 +29,7 @@ class BasicPathInfo(HookBaseClass):
     Methods for basic file path parsing.
     """
 
-    def get_publish_name(self, path, sequence=False):
+    def get_publish_name(self, path, sequence=False, return_code=False):
         """
         Given a file path, return the display name to use for publishing.
 
@@ -66,22 +66,33 @@ class BasicPathInfo(HookBaseClass):
         # frame_pattern_match = re.search(FRAME_REGEX, filename)
 
         if match:
-            publish_name = match.group("prefix")
-            # publish_name += match.group("ver_sep")
-            # publish_name += match.group("version")
+            publish_name = publish_code = match.group("prefix")
+            if match.group("version"):
+                publish_code += match.group("ver_sep")
+                publish_code += match.group("version")
             if match.group("rep"):
                 publish_name += match.group("rep_sep")
                 publish_name += match.group("rep")
+                publish_code += match.group("rep_sep")
+                publish_code += match.group("rep")
             if match.group("frame"):
                 display_str = "#" * len(match.group("frame"))
                 publish_name += match.group("frame_sep")
                 publish_name += display_str
+                publish_code += match.group("frame_sep")
+                publish_code += display_str
             publish_name += "." + match.group("ext")
+            publish_code += "." + match.group("ext")
         else:
             publish_name = filename
+            publish_code = filename
 
-        logger.debug("Returning publish name: %s" % (publish_name,))
-        return publish_name
+        if return_code:
+            logger.debug("Returning publish code: %s" % (publish_name,))
+            return publish_code
+        else:
+            logger.debug("Returning publish name: %s" % (publish_name,))
+            return publish_name
 
     def get_version_number(self, path):
         """

--- a/hooks/tk-multi-publish2/path_info.py
+++ b/hooks/tk-multi-publish2/path_info.py
@@ -87,7 +87,7 @@ class BasicPathInfo(HookBaseClass):
             publish_name = filename
             publish_code = filename
 
-        logger.debug("Returning publish name, publish code: %s, " % (publish_name, publish_code))
+        logger.debug("Returning publish name, publish code: {},{}".format(publish_name, publish_code))
         return publish_name, publish_code
 
     def get_version_number(self, path):

--- a/hooks/tk-multi-publish2/publish_file.py
+++ b/hooks/tk-multi-publish2/publish_file.py
@@ -270,7 +270,7 @@ class BasicFilePublishPlugin(HookBaseClass):
         # here such as custom type or template settings.
 
         publish_path = self.get_publish_path(settings, item)
-        publish_name = self.get_publish_name(settings, item)
+        publish_name, publish_code = self.get_publish_name(settings, item)
 
         # ---- check for conflicting publishes of this path with a status
 
@@ -346,7 +346,7 @@ class BasicFilePublishPlugin(HookBaseClass):
         # here such as custom type or template settings.
 
         publish_type = self.get_publish_type(settings, item)
-        publish_name = self.get_publish_name(settings, item)
+        publish_name, publish_code = self.get_publish_name(settings, item)
         publish_version = self.get_publish_version(settings, item)
         publish_path = self.get_publish_path(settings, item)
         publish_dependencies_paths = self.get_publish_dependencies(settings, item)
@@ -372,6 +372,7 @@ class BasicFilePublishPlugin(HookBaseClass):
             "tk": publisher.sgtk,
             "context": item.context,
             "comment": item.description,
+            "code": publish_code,
             "path": publish_path,
             "name": publish_name,
             "created_by": publish_user,
@@ -414,8 +415,7 @@ class BasicFilePublishPlugin(HookBaseClass):
             },
         )
 
-
-        ## Look for an item up the tree that has a version_name, meaning a version will be created.
+        # Look for an item up the tree that has a version_name, meaning a version will be created.
         version_name = None
         version_item = item
 
@@ -659,7 +659,7 @@ class BasicFilePublishPlugin(HookBaseClass):
         # publish name explicitly set or defined on the item
         publish_name = item.get_property("publish_name")
         if publish_name:
-            return publish_name
+            return publish_name, publish_name
 
         # fall back to the path_info logic
         publisher = self.parent


### PR DESCRIPTION
- added "out" and "dataset" to nuke image categories
- added path_info hook to all publishers
- updated publisher to display the "publish code" in the display so user can see what version they are publishing
- fixed the "sg_movie_has_slate" checkbox when attaching a move from a nuke Write node (worked on sgWrites only before)
- get_publish_name now returns publish_name and publish_code