### PR TITLE
removed mov64_write_timecode as promoted knob

### DIFF
--- a/env/includes/settings/tk-nuke-writenode.yml
+++ b/env/includes/settings/tk-nuke-writenode.yml
@@ -60,7 +60,6 @@ settings.tk-nuke-writenode.asset:
       - mov64_dnxhr_codec_profile
       - mov_h264_codec_profile
       - mov64_quality
-      - mov64_write_timecode
     proxy_publish_template:
     proxy_render_template:
     render_template: asset_nuke_work_render_mov
@@ -154,7 +153,6 @@ settings.tk-nuke-writenode.seq:
       - mov64_dnxhr_codec_profile
       - mov_h264_codec_profile
       - mov64_quality
-      - mov64_write_timecode
     proxy_publish_template:
     proxy_render_template:
     render_template: seq_nuke_work_render_mov
@@ -248,7 +246,6 @@ settings.tk-nuke-writenode.shot:
       - mov64_dnxhr_codec_profile
       - mov_h264_codec_profile
       - mov64_quality
-      - mov64_write_timecode
     proxy_publish_template:
     proxy_render_template:
     render_template: shot_nuke_work_render_mov


### PR DESCRIPTION
- promoting this knob had issues
- the knob would not check ON if it was imported from a template even if it was ON in the template
- assuming theres no good reason to turn this off, removing it as a promoted knob sets it to default ON all the time now